### PR TITLE
[FEATURE][EMGA-374] Added styling to prevent listing overflow

### DIFF
--- a/view/adminhtml/layout/experius_csp_report_index.xml
+++ b/view/adminhtml/layout/experius_csp_report_index.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
+	<head>
+		<css src="Experius_Csp::css/csp-column-word-break.css"/>
+	</head>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="experius_csp_report_listing"/>

--- a/view/adminhtml/ui_component/experius_csp_report_listing.xml
+++ b/view/adminhtml/ui_component/experius_csp_report_listing.xml
@@ -60,12 +60,18 @@
 			<settings>
 				<filter>text</filter>
 				<label translate="true">Referrer</label>
+				<fieldClass>
+					<class name="word-break-cell">true</class>
+				</fieldClass>
 			</settings>
 		</column>
 		<column name="violated_directive">
 			<settings>
 				<filter>text</filter>
 				<label translate="true">Violated Directive</label>
+				<fieldClass>
+					<class name="violated-directive-cell">true</class>
+				</fieldClass>
 			</settings>
 		</column>
 		<column name="original_policy">
@@ -79,6 +85,9 @@
 			<settings>
 				<filter>text</filter>
 				<label translate="true">Blocked URI</label>
+				<fieldClass>
+					<class name="word-break-cell">true</class>
+				</fieldClass>
 			</settings>
 		</column>
 		<column name="date">

--- a/view/adminhtml/web/css/csp-column-word-break.css
+++ b/view/adminhtml/web/css/csp-column-word-break.css
@@ -1,0 +1,8 @@
+.word-break-cell {
+    word-break: break-word;
+}
+
+.violated-directive-cell {
+    max-width: 200px;
+    word-break: normal;
+}


### PR DESCRIPTION
Added classes to the cells of three columns to add custom styling to prevent the listing/grid from overflowing the page. 
It is especially inconvenient if this happens because the action column is on the far right, and the scroll bar at the bottom of the page. 