### PR TITLE
[BUGFIX][SBN-216] Correct img-src 'data' policy in amasty base

### DIFF
--- a/etc/adminhtml/csp_whitelist.xml
+++ b/etc/adminhtml/csp_whitelist.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="img-src">
+            <values>
+                <value id="data" type="host">data:</value>
+                <value id="amasty" type="host">amasty.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
Amasty Base has the following CSP declaration in vendor/amasty/base/adminhtml/csp_whitelist.xml:
```   
<policies>
    <policy id="img-src">
        <values>
            <value id="data" type="host">amasty.com</value>
        </values>
    </policy>
</policies>
```
This overrides the core Magento declaration of `<value id="data" type="host">data:</value>`, which causes CSP errors on images in the backend
Since it's declared on adminhtml scope, it's not fixed by the img-src data declaration in the Experius_Csp module, even though it's loading sequence is later